### PR TITLE
Fixed a CA-FR mistake

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ rouille::rouille! {
 #[légal(code_inaccessible)]
 fonction secondaire() {
     merde!("oh non"); // for the true French experience
-    calisse!("tabernacle"); // for friends speaking fr-ca
+    calisse!("tabarnak"); // for friends speaking fr-ca
     oups!("fetchez la vache"); // in SFW contexts
 }
 ```


### PR DESCRIPTION
Fixed "tabernacle" (the item) being used as a swearword instead of the proper spelling.

[tabarnak](https://en.wiktionary.org/wiki/tabarnak)
[tabernacle](https://en.wikipedia.org/wiki/Tabernacle)