### PR TITLE
Réparer référence license dans lisez-moi.mon-doudou

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,4 +105,6 @@ Please don't introduce swear words, though: we will not excuse your French.
 
 ## la license
 
-[WTFPL](http://www.wtfpl.net/).
+[License Publique Rien à Branler](http://sam.zoy.org/lprab/),
+_le_ official translation of the [WTFPL](http://www.wtfpl.net/)
+by the same author.


### PR DESCRIPTION
On utilise la license RàB mais le README dit encore qu'il n'a plus de
genou.

Je ne vois pas le rapport. (Il dit qu'il ne voit pas le rapport.)