### PR TITLE
Résolution de faille critique

### DIFF
--- a/rouille_proc_macro/src/lib.rs
+++ b/rouille_proc_macro/src/lib.rs
@@ -51,7 +51,7 @@ rouille_compilogenese::rouille! {
             "prendre_ou_insérer_avec" => "get_or_insert_with",
             "principale" => "main",
             "public" => "pub",
-            "que" => None?,
+            "que" => Rien?,
             "renvoie" => "return",
             "réalisation" => "impl",
             "réf" => "ref",


### PR DESCRIPTION
(Toujours en attente d'un numéro de vulnérabilité CERTFR.)

Une non-traduction a été trouvée dans le code de Rouille. La brigade sémantique est aux aguets et le niveau d'alerte tradupirate passe au niveau carmin.

En attente de validation par un.e relecteur.ice.