### PR TITLE
Suppression de l'anglicisme dans l'exemple principal

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ rouille::rouille! {
             si soit Quelque(dico) = dangereux { DICTIONNAIRE.en_réf() } {
                 Bien(dico.lire(&clé))
             } sinon {
-                Arf("fetchez le dico".vers())
+                Arf("récupérez le dico".vers())
             }
         }
     }


### PR DESCRIPTION
« Fetcher » est un anglicisme, du verbe anglais « fetch. »

Une alternative, qui ne fait pas outrance à notre langue si bien défendue par nos poussiéreux de l'académie française, serait d'utiliser plutôt le terme courant « récupérer. »