### PR TITLE
Fix Lithuanian fork link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Please don't introduce swear words, though: we will not excuse your French.
 - Catalan: [rovell](https://github.com/gborobio73/rovell)
 - Corsican: [rughjina](https://github.com/aldebaranzbradaradjan/rughjina)
 - Indonesian: [karat](https://github.com/annurdien/karat)
-- Lithuanian: [rūdys](https://github.com/TruncatedDinosour/rudys)
+- Lithuanian: [rūdys](https://git.ari.lt/ari/rudys)
 - Greek: [skouriasmeno](https://github.com/devlocalhost/skouriasmeno)
 - Thai: [sanim (สนิม)](https://github.com/korewaChino/sanim)
 - Swiss: [roeschti](https://github.com/Georg-code/roeschti)


### PR DESCRIPTION
Migrated to: <https://git.ari.lt/ari/rudys> (last year already :') + I changed my username on GitHub anyway)

(yes sorry a fork already exists in my account and therefore I just put it on the @ari-lt org horses are gonna catch me for this deed)